### PR TITLE
feat: automatic version in pack.mcmeta

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Update version text in pack.mcmeta
+      - name: Update Resourcepack Version String
+        uses: jacobtomlinson/gha-find-replace@v3
+        with:
+          find: "DONT_TOUCH_THIS_STRING"
+          replace: ${{ steps.semantic_release_info.outputs.git_tag }}
+          include: "pack.mcmeta" # Will match the pack.mcmeta file in root
+
       # Create optimized archive for release
       - name: Compile Release Archive
         uses: ComunidadAylas/PackSquash-action@v4
@@ -64,13 +72,13 @@ jobs:
 
             # Set a custom output file path to work with the generated ZIP file
             # without needing to download its artifact in a separate step
-            output_file_path = '/tmp/alathra-${{ steps.semantic_release_info.outputs.git_tag }}.zip'
+            output_file_path = '/tmp/alathra.zip'
 
       # Create release
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
-          files: /tmp/alathra-${{ steps.semantic_release_info.outputs.git_tag }}.zip
+          files: /tmp/alathra.zip
           token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ steps.semantic_release_info.outputs.git_tag }}
           draft: false

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,6 +1,6 @@
 {
     "pack": {
-        "description": "Alathra Resource Pack",
+        "description": "Alathra Resource Pack DONT_TOUCH_THIS_STRING",
         "pack_format": 15
     }
 }


### PR DESCRIPTION
FYI, removing the version number from the release archive allows us to always point users to: https://github.com/Alathra/Alathra-Resourcepack/releases/latest/download/alathra.zip.

To ensure that release archives are still versioned the version is now located in the `pack.mcmeta`, allowing users to see the pack version in-game.