### PR TITLE
fix: Model Data Values for Tungsten and Platinum Swapped

### DIFF
--- a/assets/minecraft/models/item/copper_ingot.json
+++ b/assets/minecraft/models/item/copper_ingot.json
@@ -6,13 +6,13 @@
   "overrides": [
     {
       "predicate": {
-        "custom_model_data": 2
+        "custom_model_data": 3
       },
       "model": "item/extras/platinum_ingot"
     },
     {
       "predicate": {
-        "custom_model_data": 3
+        "custom_model_data": 2
       },
       "model": "item/extras/tungsten_ingot"
     },


### PR DESCRIPTION
I accidentally swapped two values in the cmd's